### PR TITLE
fix: improve error handling for oauth errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,12 +199,13 @@ by using the component attributes mapped to the corresponding methods of
 
 #### Events
 
-| Name                   | Type                           | Description                                                                                                                                            |
-| ---------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `picker:authenticated` | `{ token: string }`            | Triggered when the user authenticates with the provided OAuth client ID and scope.                                                                     |
-| `picker:canceled`      | `google.picker.ResponseObject` | Triggered when the user cancels the picker dialog. See [`ResponseObject`](https://developers.google.com/drive/picker/reference/picker.responseobject). |
-| `picker:picked`        | `google.picker.ResponseObject` | Triggered when the user picks one or more items. See [`ResponseObject`](https://developers.google.com/drive/picker/reference/picker.responseobject).   |
-| `picker:error`         | `google.picker.ResponseObject` | Triggered when an error occurs. See [`ResponseObject`](https://developers.google.com/drive/picker/reference/picker.responseobject).                    |
+| Name                    | Type                                       | Description                                                                                                                                            |
+| ----------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `picker:oauth:error`    | `google.accounts.oauth2.ClientConfigError` | Triggered when an error occurs in the OAuth flow. See the [error guide](https://developers.google.com/identity/oauth2/web/guides/error).               |
+| `picker:oauth:response` | `google.accounts.oauth2.ClientConfigError` | Triggered when an OAuth flow completes. See the [token model guide](https://developers.google.com/identity/oauth2/web/guides/use-token-model).         |
+| `picker:canceled`       | `google.picker.ResponseObject`             | Triggered when the user cancels the picker dialog. See [`ResponseObject`](https://developers.google.com/drive/picker/reference/picker.responseobject). |
+| `picker:picked`         | `google.picker.ResponseObject`             | Triggered when the user picks one or more items. See [`ResponseObject`](https://developers.google.com/drive/picker/reference/picker.responseobject).   |
+| `picker:error`          | `google.picker.ResponseObject`             | Triggered when an error occurs. See [`ResponseObject`](https://developers.google.com/drive/picker/reference/picker.responseobject).                    |
 
 #### Slots
 

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -248,21 +248,44 @@
 									}
 								}
 							]
+						},
+						{
+							"kind": "method",
+							"name": "retrieveAccessToken",
+							"privacy": "private",
+							"return": {
+								"type": {
+									"text": "Promise<string | undefined>"
+								}
+							}
 						}
 					],
 					"events": [
-						{
-							"name": "picker:authenticated",
-							"type": {
-								"text": "{ token: string }"
-							},
-							"description": "Triggered when the user authenticates with the provided OAuth client ID and scope."
-						},
 						{
 							"name": "eventType",
 							"type": {
 								"text": "CustomEvent"
 							}
+						},
+						{
+							"name": "picker:oauth:error",
+							"type": {
+								"text": "google.accounts.oauth2.ClientConfigError"
+							},
+							"description": "Triggered when an error occurs in the OAuth flow. See the [error guide](https://developers.google.com/identity/oauth2/web/guides/error)."
+						},
+						{
+							"name": "picker:authenticated",
+							"type": {
+								"text": "CustomEvent"
+							}
+						},
+						{
+							"name": "picker:oauth:response",
+							"type": {
+								"text": "google.accounts.oauth2.ClientConfigError"
+							},
+							"description": "Triggered when an OAuth flow completes. See the [token model guide](https://developers.google.com/identity/oauth2/web/guides/use-token-model)."
 						},
 						{
 							"type": {

--- a/src/drive-picker/drive-picker-element.ts
+++ b/src/drive-picker/drive-picker-element.ts
@@ -291,7 +291,7 @@ export class DrivePickerElement extends HTMLElement {
 					new CustomEvent("picker:authenticated", { detail: { token } }),
 				);
 				this.dispatchEvent(
-					new CustomEvent("picker:oauth:response", { detail:  response  }),
+					new CustomEvent("picker:oauth:response", { detail: response }),
 				);
 				return token;
 			})


### PR DESCRIPTION
- Adds `picker:oauth:error`and `picker:oauth:response` events
- Removed `picker:authenticated` event from the documentation

Example `picker:oauth:error` custom event below:

```js
{
  "detail": {
    "message": "Popup window closed",
    "stack": "Error: Popup window closed ...OMITTED",
    "type": "popup_closed"
  }
}
```

closes #35
