### PR TITLE
feat: add additional oauth attributes including prompt, login-hint, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,22 +180,26 @@ by using the component attributes mapped to the corresponding methods of
 
 #### Attributes
 
-| Name             | Type                         | Description                                                                                                                                                                                             |
-| ---------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `app-id`         | `string`                     | The Google Drive app ID. See [`PickerBuilder.setAppId`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.setappid).                                                            |
-| `client-id`      | `string`                     | The OAuth 2.0 client ID. See [Using OAuth 2.0 to Access Google APIs](https://developers.google.com/identity/protocols/oauth2).                                                                          |
-| `developer-key`  | `string`                     | The API key for accessing Google Picker API. See [`PickerBuilder.setDeveloperKey`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.setdeveloperkey).                          |
-| `hide-title-bar` | `"default"\|"true"\|"false"` | Hides the title bar of the picker if set to true. See [`PickerBuilder.hideTitleBar`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.hidetitlebar).                           |
-| `locale`         | `string`                     | The locale to use for the picker. See [`PickerBuilder.setLocale`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.setlocale).                                                 |
-| `max-items`      | `number`                     | The maximum number of items that can be selected. See [`PickerBuilder.setMaxItems`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.setmaxitems).                             |
-| `mine-only`      | `boolean`                    | If set to true, only shows files owned by the user. See [`PickerBuilder.enableFeature`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.enablefeature).                       |
-| `multiselect`    | `boolean`                    | Enables multiple file selection if set to true. See [`PickerBuilder.enableFeature`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.enablefeature).                           |
-| `nav-hidden`     | `boolean`                    | Hides the navigation pane if set to true. See [`PickerBuilder.enableFeature`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.enablefeature).                                 |
-| `oauth-token`    | `string`                     | The OAuth 2.0 token for authentication. See [`PickerBuilder.setOAuthToken`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.setoauthtoken).                                   |
-| `origin`         | `string`                     | The origin parameter for the picker. See [`PickerBuilder.setOrigin`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.setorigin).                                              |
-| `relay-url`      | `string`                     | The relay URL for the picker. See [`PickerBuilder.setRelayUrl`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.setrelayurl).                                                 |
-| `scope`          | `string`                     | The OAuth 2.0 scope for the picker. The default is `https://www.googleapis.com/auth/drive.file`. See [Drive API scopes](https://developers.google.com/drive/api/guides/api-specific-auth#drive-scopes). |
-| `title`          | `string`                     | The title of the picker. See [`PickerBuilder.setTitle`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.settitle).                                                            |
+| Name                     | Type                                      | Description                                                                                                                                                                                             |
+| ------------------------ | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `app-id`                 | `string`                                  | The Google Drive app ID. See [`PickerBuilder.setAppId`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.setappid).                                                            |
+| `client-id`              | `string`                                  | The OAuth 2.0 client ID. See [Using OAuth 2.0 to Access Google APIs](https://developers.google.com/identity/protocols/oauth2).                                                                          |
+| `developer-key`          | `string`                                  | The API key for accessing Google Picker API. See [`PickerBuilder.setDeveloperKey`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.setdeveloperkey).                          |
+| `hide-title-bar`         | `"default"\|"true"\|"false"`              | Hides the title bar of the picker if set to true. See [`PickerBuilder.hideTitleBar`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.hidetitlebar).                           |
+| `locale`                 | `string`                                  | The locale to use for the picker. See [`PickerBuilder.setLocale`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.setlocale).                                                 |
+| `max-items`              | `number`                                  | The maximum number of items that can be selected. See [`PickerBuilder.setMaxItems`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.setmaxitems).                             |
+| `mine-only`              | `boolean`                                 | If set to true, only shows files owned by the user. See [`PickerBuilder.enableFeature`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.enablefeature).                       |
+| `multiselect`            | `boolean`                                 | Enables multiple file selection if set to true. See [`PickerBuilder.enableFeature`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.enablefeature).                           |
+| `nav-hidden`             | `boolean`                                 | Hides the navigation pane if set to true. See [`PickerBuilder.enableFeature`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.enablefeature).                                 |
+| `oauth-token`            | `string`                                  | The OAuth 2.0 token for authentication. See [`PickerBuilder.setOAuthToken`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.setoauthtoken).                                   |
+| `origin`                 | `string`                                  | The origin parameter for the picker. See [`PickerBuilder.setOrigin`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.setorigin).                                              |
+| `relay-url`              | `string`                                  | The relay URL for the picker. See [`PickerBuilder.setRelayUrl`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.setrelayurl).                                                 |
+| `scope`                  | `string`                                  | The OAuth 2.0 scope for the picker. The default is `https://www.googleapis.com/auth/drive.file`. See [Drive API scopes](https://developers.google.com/drive/api/guides/api-specific-auth#drive-scopes). |
+| `title`                  | `string`                                  | The title of the picker. See [`PickerBuilder.setTitle`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.settitle).                                                            |
+| `hd`                     | `string`                                  | The hosted domain to restrict sign-in to. (Optional) See the `hd` field in the OpenID Connect docs.                                                                                                     |
+| `include-granted-scopes` | `boolean`                                 | Enables applications to use incremental authorization. See [`TokenClientConfig.include_granted_scopes`](https://developers.google.com/identity/oauth2/web/reference/js-reference#TokenClientConfig).    |
+| `login-hint`             | `string`                                  | An email address or an ID token 'sub' value. Google will use the value as a hint of which user to sign in. See the `login_hint` field in the OpenID Connect docs.                                       |
+| `prompt`                 | `""\|"none"\|"consent"\|"select_account"` | A space-delimited, case-sensitive list of prompts to present the user. See [`TokenClientConfig.prompt`](https://developers.google.com/identity/oauth2/web/reference/js-reference#TokenClientConfig)     |
 
 #### Events
 
@@ -215,9 +219,15 @@ by using the component attributes mapped to the corresponding methods of
 
 #### Properties
 
-| Name      | Type      | Description                                                                                                                                                                          |
-| --------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `visible` | `boolean` | Controls the visibility of the picker after the picker dialog has been&#xA;closed. If any of the attributes change, the picker will be rebuilt and&#xA;the visibility will be reset. |
+| Name                | Type      | Description                                                                                                                                                                          |
+| ------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `visible`           | `boolean` | Controls the visibility of the picker after the picker dialog has been&#xA;closed. If any of the attributes change, the picker will be rebuilt and&#xA;the visibility will be reset. |
+| `tokenClientConfig` | \`Omit<   |                                                                                                                                                                                      |
+
+```
+	google.accounts.oauth2.TokenClientConfig,
+	"callback" \| "error_callback" 	>` |                                                                                                                                                                                      |
+```
 
 ### `<drive-picker-docs-view/>`
 

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -222,6 +222,15 @@
 							"description": "Controls the visibility of the picker after the picker dialog has been\nclosed. If any of the attributes change, the picker will be rebuilt and\nthe visibility will be reset."
 						},
 						{
+							"kind": "field",
+							"name": "tokenClientConfig",
+							"type": {
+								"text": "Omit<\n\t\tgoogle.accounts.oauth2.TokenClientConfig,\n\t\t\"callback\" | \"error_callback\"\n\t>"
+							},
+							"privacy": "public",
+							"readonly": true
+						},
+						{
 							"kind": "method",
 							"name": "build",
 							"privacy": "private"
@@ -251,7 +260,7 @@
 						},
 						{
 							"kind": "method",
-							"name": "retrieveAccessToken",
+							"name": "requestAccessToken",
 							"privacy": "private",
 							"return": {
 								"type": {
@@ -407,6 +416,34 @@
 								"text": "string"
 							},
 							"description": "The title of the picker. See [`PickerBuilder.setTitle`](https://developers.google.com/drive/picker/reference/picker.pickerbuilder.settitle)."
+						},
+						{
+							"type": {
+								"text": "string"
+							},
+							"description": "The hosted domain to restrict sign-in to.  (Optional)  See the `hd` field in the OpenID Connect docs.",
+							"name": "hd"
+						},
+						{
+							"type": {
+								"text": "boolean"
+							},
+							"description": "Enables applications to use incremental authorization. See [`TokenClientConfig.include_granted_scopes`](https://developers.google.com/identity/oauth2/web/reference/js-reference#TokenClientConfig).",
+							"name": "include-granted-scopes"
+						},
+						{
+							"type": {
+								"text": "string"
+							},
+							"description": "An email address or an ID token 'sub' value. Google will use the value as a hint of which user to sign in. See the `login_hint` field in the OpenID Connect docs.",
+							"name": "login-hint"
+						},
+						{
+							"type": {
+								"text": "\"\"|\"none\"|\"consent\"|\"select_account\""
+							},
+							"description": "A space-delimited, case-sensitive list of prompts to present the user.  See [`TokenClientConfig.prompt`](https://developers.google.com/identity/oauth2/web/reference/js-reference#TokenClientConfig)",
+							"name": "prompt"
 						}
 					],
 					"superclass": {

--- a/src/stories/utils/manifest-helpers.ts
+++ b/src/stories/utils/manifest-helpers.ts
@@ -67,12 +67,32 @@ export const elementArgTypes: {
 					case "number":
 						inputType.control = "number";
 						break;
-					case '"default"|"true"|"false"':
-						inputType.control = "select";
-						inputType.options = ["default", "true", "false"];
-						break;
 					default:
-						throw new Error(`Unsupported type: ${attr.type?.text}`);
+						// check if string literal union such as "default"|"true"|"false"
+						if (
+							attr.type?.text.match(/"[a-zA-Z-0-9-_"]*"/) &&
+							attr.type?.text.includes("|")
+						) {
+							inputType.control = "select";
+							inputType.options = attr.type?.text.replace(/"/g, "").split("|");
+						} else {
+							throw new Error(`Unsupported type: ${attr.type?.text}`);
+						}
+				}
+
+				if (
+					tagName === "drive-picker" &&
+					[
+						"client-id",
+						"scope",
+						"hd",
+						"prompt",
+						"login-hint",
+						"include-granted-scopes",
+					].includes(attr.name)
+				) {
+					// biome-ignore lint/style/noNonNullAssertion: <explanation>
+					inputType!.table!.category = "OAuth";
 				}
 
 				return [attr.name, inputType];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,17 +37,18 @@ export class ClientConfigError extends Error {
 	}
 }
 
-export async function retrieveAccessToken(
-	clientId: string,
-	scope: string,
+export async function requestAccessToken(
+	tokenClientConfig: Omit<
+		google.accounts.oauth2.TokenClientConfig,
+		"callback" | "error_callback"
+	>,
 ): Promise<google.accounts.oauth2.TokenResponse> {
 	if (!window.google?.accounts?.oauth2) {
 		await injectScript(GSI_URL);
 	}
 	return new Promise((resolve, reject) => {
 		const client = window.google.accounts.oauth2.initTokenClient({
-			client_id: clientId,
-			scope: scope.replace(/,/g, " ").replace(/\s+/g, " "),
+			...tokenClientConfig,
 			callback: resolve,
 			error_callback: reject,
 		});


### PR DESCRIPTION
```html
<drive-picker
  app-id="YOUR_APP_ID"
  client-id="YOUR_CLIENT_ID"
  prompt=""
  login-hint="me@jpoehnelt.dev"
  scope="https://www.googleapis.com/auth/drive.file profile email"
  hd=""
>
  <drive-picker-docs-view></drive-picker-docs-view>
</drive-picker>
```

The `picker:oauth:response` event object looks like this with the above attributes:

```js

{
  "access_token": "ya29.OMITTED",
  "authuser": "1",
  "expires_in": 3599,
  "prompt": "consent",
  "scope": "email profile https://www.googleapis.com/auth/userinfo.email openid https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/drive.file",
  "token_type": "Bearer"
}
```

also split category for oauth in storyboook table

![image](https://github.com/user-attachments/assets/4086fb78-cddd-4c11-ba51-06bd10177d73)

cc #37

