### PR TITLE
fix: ensure component initializes on connection

### DIFF
--- a/src/drive-picker/drive-picker-element.ts
+++ b/src/drive-picker/drive-picker-element.ts
@@ -181,6 +181,8 @@ export class DrivePickerElement extends HTMLElement {
 	}
 
 	attributeChangedCallback() {
+		if (!this.isConnected) return;
+
 		this.scheduleBuild();
 	}
 
@@ -302,6 +304,8 @@ export class DrivePickerElement extends HTMLElement {
 			subtree: true,
 			attributes: true,
 		});
+
+		this.scheduleBuild();
 	}
 
 	private callbackToDispatchEvent(detail: google.picker.ResponseObject) {


### PR DESCRIPTION
This PR addresses a lifecycle issue where the drive-picker-element would not render upon initial connection to the DOM. It would only render after an attribute was changed.

The fix involves two main changes:

- The scheduleBuild() method is now called within connectedCallback to ensure the picker is built as soon as the element is added to the page.
- A guard (if (!this.isConnected)) has been added to attributeChangedCallback to prevent it from running before the element is connected, making the component more robust.

closes #79 