### PR TITLE
fix: Add console warning for missing `app-id` attribute

### DIFF
--- a/.changeset/kind-bugs-nail.md
+++ b/.changeset/kind-bugs-nail.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/drive-picker-element": patch
+---
+
+Add a console warning when the `app-id` attribute is missing. While the picker may function without it, `app-id` is often required for backend API integration (e.g., `drive.files.get`). This warning helps developers identify potential configuration issues earlier.

--- a/packages/drive-picker-element/src/drive-picker/drive-picker-element.ts
+++ b/packages/drive-picker-element/src/drive-picker/drive-picker-element.ts
@@ -213,7 +213,13 @@ export class DrivePickerElement extends HTMLElement {
 		);
 
 		const appId = this.getAttribute("app-id");
-		if (appId !== null) builder = builder.setAppId(appId);
+		if (appId !== null) {
+			builder = builder.setAppId(appId);
+		} else {
+			console.warn(
+				"drive-picker: app-id attribute is missing. This may cause issues with backend API integration.",
+			);
+		}
 
 		const developerKey = this.getAttribute("developer-key");
 		if (developerKey !== null) builder = builder.setDeveloperKey(developerKey);

--- a/packages/drive-picker-element/src/drive-picker/drive-picker-element.ts
+++ b/packages/drive-picker-element/src/drive-picker/drive-picker-element.ts
@@ -213,7 +213,7 @@ export class DrivePickerElement extends HTMLElement {
 		);
 
 		const appId = this.getAttribute("app-id");
-		if (appId !== null) {
+		if (appId) {
 			builder = builder.setAppId(appId);
 		} else {
 			console.warn(


### PR DESCRIPTION
closes #95 