### PR TITLE
docs: add Content Security Policy (CSP) example for drive-picker-element with supporting configurations and documentation.

### DIFF
--- a/.changeset/csp-documentation.md
+++ b/.changeset/csp-documentation.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/drive-picker-element": patch
+---
+
+Added Content Security Policy (CSP) guide and example.

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Config for the Gemini Pull Request Review Bot.
 # https://github.com/marketplace/gemini-code-assist
 have_fun: false

--- a/examples/csp/README.md
+++ b/examples/csp/README.md
@@ -1,0 +1,40 @@
+# Drive Picker CSP Example
+
+This example demonstrates how to use the `@googleworkspace/drive-picker-element` in an environment with a Content Security Policy (CSP).
+
+## Key Features
+
+1.  **CSP Meta Tag**: The `index.html` includes a `<meta http-equiv="Content-Security-Policy">` tag that defines the allowed sources for scripts, frames, styles, and images.
+2.  **Pre-loaded Scripts**: The Google API scripts (`api.js` and `client`) are loaded via `<script>` tags in the `<head>`. This prevents the `drive-picker-element` from attempting to dynamically inject them, which is often blocked by strict CSPs.
+3.  **Frame Source**: The `frame-src` directive includes `https://docs.google.com` and `https://drive.google.com` to allow the Picker iframe to load.
+
+## Usage
+
+1.  Install dependencies:
+
+    ```bash
+    pnpm install
+    ```
+
+2.  Start the development server:
+
+    ```bash
+    pnpm dev
+    ```
+
+3.  Open the browser and verify that the Picker loads correctly (you will need to provide a valid `client-id` and `app-id` in `index.html` or `src/main.ts`).
+
+## CSP Configuration
+
+The CSP used in this example is:
+
+```http
+Content-Security-Policy:
+  default-src 'self';
+  script-src 'self' https://apis.google.com https://accounts.google.com;
+  frame-src 'self' https://docs.google.com https://drive.google.com https://accounts.google.com;
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' https://*.googleusercontent.com;
+  connect-src 'self' https://*.googleapis.com;
+  font-src 'self' https://fonts.gstatic.com;
+```

--- a/examples/csp/index.html
+++ b/examples/csp/index.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Drive Picker CSP Example</title>
+    <!-- 
+      Content Security Policy (CSP)
+      
+      script-src: 
+        - 'self': Allow scripts from this origin
+        - https://apis.google.com: Required for Google API Client Library
+        - https://accounts.google.com: Required for Google Identity Services
+      
+      frame-src:
+        - 'self': Allow frames from this origin
+        - https://docs.google.com: Required for the Picker iframe
+        - https://drive.google.com: Required for the Picker iframe
+        - https://accounts.google.com: Required for authentication frames
+      
+      style-src:
+        - 'self': Allow styles from this origin
+        - 'unsafe-inline': Required for some Google styles (can be tightened with nonces)
+        
+      img-src:
+        - 'self': Allow images from this origin
+        - https://*.googleusercontent.com: Required for profile pictures and thumbnails
+
+      font-src:
+        - 'self': Allow fonts from this origin
+        - https://fonts.gstatic.com: Required for Google Fonts
+    -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="
+        default-src 'self';
+        script-src 'self' https://apis.google.com https://accounts.google.com;
+        frame-src 'self' https://docs.google.com https://drive.google.com https://accounts.google.com;
+        style-src 'self' 'unsafe-inline';
+        img-src 'self' https://*.googleusercontent.com;
+        connect-src 'self' https://*.googleapis.com;
+        font-src 'self' https://fonts.gstatic.com;
+      "
+    />
+
+    <!-- 
+      Pre-load Google API scripts.
+      This prevents the drive-picker-element from attempting to dynamically inject them,
+      which might be blocked by stricter CSPs (e.g. if script-src didn't allow dynamic injection).
+    -->
+<script src="https://apis.google.com/js/api.js" async defer></script>
+<script src="https://accounts.google.com/gsi/client" async defer></script>
+  </head>
+  <body>
+    <div id="app">
+      <h1>Drive Picker CSP Example</h1>
+      <p>
+        This example demonstrates how to use the Drive Picker with a Content
+        Security Policy.
+      </p>
+
+      <!-- 
+        Replace client-id and app-id with your own values.
+        You can also set them via JavaScript.
+      -->
+      <drive-picker id="picker" client-id="YOUR_CLIENT_ID" app-id="YOUR_APP_ID">
+        <drive-picker-docs-view></drive-picker-docs-view>
+      </drive-picker>
+
+      <button id="open-picker">Open Picker</button>
+      <div id="result"></div>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/csp/index.html
+++ b/examples/csp/index.html
@@ -1,4 +1,20 @@
 <!doctype html>
+<!--
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -48,8 +64,8 @@
       This prevents the drive-picker-element from attempting to dynamically inject them,
       which might be blocked by stricter CSPs (e.g. if script-src didn't allow dynamic injection).
     -->
-<script src="https://apis.google.com/js/api.js" async defer></script>
-<script src="https://accounts.google.com/gsi/client" async defer></script>
+    <script src="https://apis.google.com/js/api.js" async defer></script>
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
   </head>
   <body>
     <div id="app">

--- a/examples/csp/package.json
+++ b/examples/csp/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "csp-example",
+	"private": true,
+	"version": "0.0.0",
+	"type": "module",
+	"scripts": {
+		"dev": "vite",
+		"build": "tsc && vite build",
+		"preview": "vite preview"
+	},
+	"dependencies": {
+		"@googleworkspace/drive-picker-element": "workspace:*"
+	},
+	"devDependencies": {
+		"typescript": "catalog:",
+		"vite": "^5.2.0"
+	}
+}

--- a/examples/csp/src/main.ts
+++ b/examples/csp/src/main.ts
@@ -1,0 +1,36 @@
+import "@googleworkspace/drive-picker-element";
+import type {
+	DrivePickerElement,
+	PickerPickedEvent,
+} from "@googleworkspace/drive-picker-element";
+
+const picker = document.getElementById("picker") as DrivePickerElement;
+const openButton = document.getElementById("open-picker") as HTMLButtonElement;
+const resultDiv = document.getElementById("result") as HTMLDivElement;
+
+// Optional: Set credentials via JS if not in HTML
+// picker.setAttribute('client-id', 'YOUR_CLIENT_ID');
+// picker.setAttribute('app-id', 'YOUR_APP_ID');
+
+openButton.addEventListener("click", () => {
+	picker.visible = true;
+});
+
+picker.addEventListener("picker-picked", (e: Event) => {
+	const event = e as PickerPickedEvent;
+	console.log("Picked:", event.detail);
+	resultDiv.innerHTML = '';
+	const pre = document.createElement('pre');
+	pre.textContent = JSON.stringify(event.detail, null, 2);
+	resultDiv.appendChild(pre);
+});
+
+picker.addEventListener("picker-canceled", () => {
+	console.log("Canceled");
+	resultDiv.textContent = "Picker canceled";
+});
+
+picker.addEventListener("picker-oauth-error", (e) => {
+	console.error("OAuth Error", e);
+	resultDiv.textContent = "OAuth Error: " + JSON.stringify(e);
+});

--- a/examples/csp/src/main.ts
+++ b/examples/csp/src/main.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import "@googleworkspace/drive-picker-element";
 import type {
 	DrivePickerElement,
@@ -19,8 +35,8 @@ openButton.addEventListener("click", () => {
 picker.addEventListener("picker-picked", (e: Event) => {
 	const event = e as PickerPickedEvent;
 	console.log("Picked:", event.detail);
-	resultDiv.innerHTML = '';
-	const pre = document.createElement('pre');
+	resultDiv.innerHTML = "";
+	const pre = document.createElement("pre");
 	pre.textContent = JSON.stringify(event.detail, null, 2);
 	resultDiv.appendChild(pre);
 });

--- a/examples/csp/tsconfig.json
+++ b/examples/csp/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"useDefineForClassFields": true,
+		"module": "ESNext",
+		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"skipLibCheck": true,
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true
+	},
+	"include": ["src"]
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 		"lint": "prettier --write . && biome check --write .",
 		"prepare": "husky",
 		"test": "turbo test",
-		"dev": "turbo dev"
+		"dev": "turbo dev",
+		"preview": "turbo preview"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "catalog:",

--- a/packages/drive-picker-element/.storybook/page.css
+++ b/packages/drive-picker-element/.storybook/page.css
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .docblock-argstable-head th:nth-child(3),
 .docblock-argstable-body td:nth-child(3) {
 	display: none;

--- a/packages/drive-picker-element/README.md
+++ b/packages/drive-picker-element/README.md
@@ -26,6 +26,7 @@ See the framework specific demos:
   - [Event Details](#event-details)
   - [Controlling Visibility](#controlling-visibility)
   - [React and JSX](#react-and-jsx)
+  - [Content Security Policy (CSP)](#content-security-policy-csp)
 - [Support](#support)
 - [Reference](#reference)
   - [`<drive-picker/>`](#drive-picker)
@@ -280,6 +281,41 @@ export default function DrivePicker() {
 2. **Proper cleanup**: Always remove event listeners in the cleanup function to prevent memory leaks.
 
 3. **Wait for the element**: Make sure the ref is populated before adding event listeners.
+
+### Content Security Policy (CSP)
+
+This library dynamically loads the Google API scripts (`https://apis.google.com/js/api.js` and `https://accounts.google.com/gsi/client`) if they are not already present. This may violate strict CSP settings that disallow dynamic script injection or restrict script sources.
+
+To use this library in a strict CSP environment:
+
+1.  **Pre-load the scripts**: Manually include the Google API scripts in your HTML using `<script>` tags that comply with your CSP (e.g., using a `nonce` or allowing the domain).
+
+    ```html
+    <script src="https://apis.google.com/js/api.js" async defer></script>
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
+    ```
+
+2.  **Ensure global objects are available**: The library checks for `window.gapi` and `window.google.accounts.oauth2`. If these are present, it skips the dynamic injection.
+
+3.  **Allow Google domains in CSP**: You must allow the picker's origin and other Google domains in your `Content-Security-Policy`. Here is a complete example:
+
+    ```http
+    Content-Security-Policy:
+      default-src 'self';
+      script-src 'self' https://apis.google.com https://accounts.google.com;
+      frame-src 'self' https://docs.google.com https://drive.google.com https://accounts.google.com;
+      style-src 'self' 'unsafe-inline';
+      img-src 'self' https://*.googleusercontent.com;
+      connect-src 'self' https://*.googleapis.com;
+      font-src 'self' https://fonts.gstatic.com;
+    ```
+
+    **Notes:**
+    - The `frame-src` domains are required for the Picker iframe and authentication. The exact domains may vary, but these are the most common.
+    - `style-src: 'unsafe-inline'` may be required for some styles injected by the Picker. For a stricter policy, you can use [nonces](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#unsafe_inline_styles).
+
+**Note for Chrome Extensions (Manifest V3):**
+The underlying Google Picker API relies on `gapi`, which is [not supported in Manifest V3 extensions](https://github.com/google/google-api-javascript-client/blob/master/docs/start.md#supported-environments). Therefore, this library may not function in that environment regardless of CSP settings.
 
 ## Support
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,19 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  examples/csp:
+    dependencies:
+      '@googleworkspace/drive-picker-element':
+        specifier: workspace:*
+        version: link:../../packages/drive-picker-element
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: ^5.2.0
+        version: 5.4.21(@types/node@24.10.1)
+
   examples/react:
     dependencies:
       '@googleworkspace/drive-picker-react':

--- a/turbo.json
+++ b/turbo.json
@@ -30,6 +30,10 @@
 		"dev": {
 			"cache": false,
 			"persistent": true
+		},
+		"preview": {
+			"cache": false,
+			"persistent": true
 		}
 	}
 }


### PR DESCRIPTION
closes #48